### PR TITLE
Proposed change to the Preconditions and the description of RFC8145 

### DIFF
--- a/draft-ietf-dnsop-dnssec-kskroll-sentinel.xml
+++ b/draft-ietf-dnsop-dnssec-kskroll-sentinel.xml
@@ -300,14 +300,15 @@
       <section anchor="precond" title="Preconditions">
         <t>All of the following conditions must be met to trigger special
         processing inside resolver code: <list style="symbols">
-            <t>The DNS response is DNSSEC validated, and the result of
-            validation is "Secure"</t>
+            <t>The DNS response is DNSSEC validated</t>
+
+            <t>the result of validation is "Secure"</t>
+
+            <t>the AD bit is to be set in the response</t>
 
             <t>The QTYPE is either A or AAAA (Query Type value 1 or 28)</t>
 
             <t>The OPCODE is QUERY</t>
-
-            <t>CD bit in the query is not set</t>
 
             <t>The leftmost label of the original QNAME (the name sent in the
             Question Section in the orignal query) is either

--- a/draft-ietf-dnsop-dnssec-kskroll-sentinel.xml
+++ b/draft-ietf-dnsop-dnssec-kskroll-sentinel.xml
@@ -124,11 +124,13 @@
       the different resolvers, or might not, depending on how the browser or
       operating system is configured.</t>
 
-      <t>Note that the sentinel mechanism described here measures a very
-      different (and likely more useful) metric than <xref target="RFC8145"/>.
-      RFC 8145 relies on resolvers reporting the list of keys that they have
-      to root servers. That reflects on how many resolvers will be impacted by
-      a KSK roll, but not what the user impact of the KSK roll will be.</t>
+      <t>Note that the sentinel mechanism described here measures a
+      very different (and likely more useful) metric than <xref
+      target="RFC8145"/>. RFC 8145 relies on resolvers reporting
+      towards the root servers a list of locally cached trust anchors
+      for the root zone. Those reports can be used to infer how many
+      resolvers may be impacted by a KSK roll, but not what the user
+      impact of the KSK roll will be.</t>
 
       <section title="Terminology">
         <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
@@ -298,13 +300,14 @@
       <section anchor="precond" title="Preconditions">
         <t>All of the following conditions must be met to trigger special
         processing inside resolver code: <list style="symbols">
-            <t>The DNS response is DNSSEC validated, regardless of whether
-            DNSSSEC validation was requested, and result of validation is
-            "Secure"</t>
+            <t>The DNS response is DNSSEC validated, and the result of
+            validation is "Secure"</t>
 
             <t>The QTYPE is either A or AAAA (Query Type value 1 or 28)</t>
 
             <t>The OPCODE is QUERY</t>
+
+            <t>CD bit in the query is not set</t>
 
             <t>The leftmost label of the original QNAME (the name sent in the
             Question Section in the orignal query) is either
@@ -568,6 +571,12 @@
 
       <t>Note that this document is being worked on in GitHub - see Abstract.
       The below is mainly large changes, and is not authoritative.</t>
+
+      <t>From -09 to -10:<list style="symbols">
+          <t>Clarified the precondition of the CD bit not set in queries.</t>
+
+          <t>Clarified the language referring to the operation of RFC8145 signalling.</t>
+        </list></t>
 
       <t>From -08 to -09:<list style="symbols">
           <t>Incorporated Paul Hoffman's PR # 15 (Two issues from the


### PR DESCRIPTION
The first change is a minor revision to the description of RFC8145 to address a potential ambiguity of the expression

The second is more substantive - it reverses the intent of the change made in -09 where the phrase "irrespective of whether validation was requested" and instead adds an explicit precondition that the CD bit is not set in the query. This is to ensure that the behaviour of the resolver matches its intended behaviour when the new KSK is installed