### PR TITLE
Make Abstract more palatable for IETF Last Call

### DIFF
--- a/draft-ietf-dnsop-dnssec-kskroll-sentinel.xml
+++ b/draft-ietf-dnsop-dnssec-kskroll-sentinel.xml
@@ -56,22 +56,12 @@
       queries. Note that this method is only applicable for determining which
       keys are in the trust store for the root key.</t>
 
-      <t>There is an example / toy implementation of this at
-      http://www.ksk-test.net .</t>
-
       <t>[ This document is being collaborated on in Github at:
       https://github.com/APNIC-Labs/draft-kskroll-sentinel. The most recent
       version of the document, open issues, etc should all be available here.
       The authors (gratefully) accept pull requests. Text in square brackets
       will be removed before publication. ]</t>
 
-      <t>[ NOTE: This version uses the labels "root-key-sentinel-is-ta-", and
-      "root-key-sentinel-not-ta-".; older versions of this document used
-      "kskroll-sentinel-is-ta-&lt;key-tag&gt;",
-      "kskroll-sentinel-not-ta-&lt;key-tag&gt;", and before that,
-      "_is-ta-&lt;key-tag&gt;", "_not-ta-&lt;key-tag&gt;". Also note that the
-      format of the tag-index is now zero-filled decimal. Apologies to those
-      who have begun implementing earlier versions of this specification.]</t>
     </abstract>
   </front>
 


### PR DESCRIPTION
If you really want to mention Warren's implementation, it needs to say "implementation of the client side of this protocol", but that will be confusing before someone has read the document.

The note about versions will cause doubt during IETF Last Call and is no longer current.